### PR TITLE
Use consistency level ONE while inserting vectors.

### DIFF
--- a/vectordb_bench/backend/clients/scylladb/scylladb.py
+++ b/vectordb_bench/backend/clients/scylladb/scylladb.py
@@ -102,7 +102,7 @@ class ScyllaDB(VectorDB):
     ) -> (int, Exception | None):
         """Insert embeddings into ScyllaDB"""
         try:
-            batch = BatchStatement(consistency_level=ConsistencyLevel.ANY, batch_type=BatchType.UNLOGGED)
+            batch = BatchStatement(consistency_level=ConsistencyLevel.ONE, batch_type=BatchType.UNLOGGED)
             for key, embedding in zip(metadata, embeddings, strict=False):
                 batch.add(self.prepared_insert, (key, embedding))
             self.session.execute(batch)


### PR DESCRIPTION
We should not use CL=Any because:
 * this is what we recommend to our users and we would like to have realistic benchmark
 * it generates alert in monitoring (looks poorly during demo)

Changing to CL=ONE instead.

Fixes VECTOR-177