### PR TITLE
Do not recreate table and index if not requested

### DIFF
--- a/vectordb_bench/backend/clients/scylladb/scylladb.py
+++ b/vectordb_bench/backend/clients/scylladb/scylladb.py
@@ -55,10 +55,10 @@ class ScyllaDB(VectorDB):
         self.session.set_keyspace(keyspace)
         
         if self.drop_old_table:
-                log.info(f"Dropping old table: {self.table_name}")
-                self.session.execute(f"DROP TABLE IF EXISTS {self.table_name}")
-        self._create_table()
-        self._create_index()
+            log.info(f"Dropping old table: {self.table_name}")
+            self.session.execute(f"DROP TABLE IF EXISTS {self.table_name}")
+            self._create_table()
+            self._create_index()
 
         self.cluster = None
         self.session = None


### PR DESCRIPTION
If the field indicating that index already exists is selected in the UI we should not drop table as it is currently implemented but also we should not create new one. Currently, each time new index is created.

Fixes: VECTOR-265