### PR TITLE
Fix insert error when db_lable not set

### DIFF
--- a/vectordb_bench/backend/clients/scylladb/scylladb.py
+++ b/vectordb_bench/backend/clients/scylladb/scylladb.py
@@ -129,7 +129,7 @@ class ScyllaDB(VectorDB):
         try:
             batch = BatchStatement(consistency_level=ConsistencyLevel.ONE, batch_type=BatchType.UNLOGGED)
             for key, embedding, label in zip_longest(metadata, embeddings, labels_data or [], fillvalue=None):
-                batch.add(self.prepared_insert, (key, embedding, label))
+                batch.add(self.prepared_insert, (key, embedding, label or ""))
             self.session.execute(batch)
         except Exception as e:
             return 0, e


### PR DESCRIPTION
When db label is not set (defaut) the insert to db generates following error: "Invalid null value in condition for column filtering_label". This is because the lable is None (null), which is not allowed according to schema. Now it is empty string instead of null.