### PR TITLE
Add local/global index scope option for ScyllaDB label-filter search

### DIFF
--- a/vectordb_bench/backend/clients/scylladb/config.py
+++ b/vectordb_bench/backend/clients/scylladb/config.py
@@ -5,6 +5,11 @@ from pydantic import BaseModel
 
 from ..api import DBCaseConfig, DBConfig, IndexType, MetricType
 
+class ScyllaDBIndexScope(str, Enum):
+    LOCAL = "local"
+    GLOBAL = "global"
+
+
 class Quantization(str, Enum):
     F32 = "f32"
     F16 = "f16"
@@ -33,6 +38,7 @@ class ScyllaDBIndexConfig(BaseModel, DBCaseConfig):
     quantization: Quantization | None = Quantization.F32  # Quantization type
     rescoring: bool | None = False  # Whether to rescore search result with original vectors
     oversampling: float | None = 1.0  # Search for oversampling * LIMIT results to improve recall
+    index_scope: ScyllaDBIndexScope = ScyllaDBIndexScope.LOCAL  # Local vs global secondary index
 
     def get_similarity_function_name(self) -> str:
         if self.metric_type == MetricType.COSINE:

--- a/vectordb_bench/backend/clients/scylladb/scylladb.py
+++ b/vectordb_bench/backend/clients/scylladb/scylladb.py
@@ -17,10 +17,10 @@ from cassandra.query import BatchStatement, BatchType, PreparedStatement
 from vectordb_bench.backend.filter import Filter, FilterOp
 
 from ..api import VectorDB
+from .config import ScyllaDBIndexScope
 
 if TYPE_CHECKING:
     from collections.abc import Generator, Sequence
-
     from .config import ScyllaDBIndexConfig
 
 __all__ = ["ScyllaDB"]
@@ -202,6 +202,14 @@ class ScyllaDB(VectorDB):
 
     # -- schema management ---------------------------------------------------
 
+    @property
+    def _use_local_index(self) -> bool:
+        """Whether to use a local (partition-level) secondary index."""
+        return (
+            self.with_scalar_labels
+            and self.case_config.index_scope == ScyllaDBIndexScope.LOCAL
+        )
+
     def _create_keyspace(self, session: Session, keyspace: str) -> None:
         """Create keyspace if it does not exist."""
         log.info("%s creating keyspace: %s", self.name, keyspace)
@@ -217,11 +225,12 @@ class ScyllaDB(VectorDB):
 
     def _create_table(self, session: Session) -> None:
         """Create table for vector storage."""
-        pk = (
-            f"PRIMARY KEY ({self.id_col_name}, {self.label_col_name})"
-            if self.with_scalar_labels
-            else f"PRIMARY KEY ({self.id_col_name})"
-        )
+        if self._use_local_index:
+            pk = f"PRIMARY KEY ({self.label_col_name}, {self.id_col_name})"
+        elif self.with_scalar_labels:
+            pk = f"PRIMARY KEY ({self.id_col_name}, {self.label_col_name})"
+        else:
+            pk = f"PRIMARY KEY ({self.id_col_name})"
         label_col = (
             f"{self.label_col_name} text,"
             if self.with_scalar_labels
@@ -240,9 +249,13 @@ class ScyllaDB(VectorDB):
 
     def _create_index(self, session: Session) -> None:
         """Create vector search index on the table."""
+        if self._use_local_index:
+            target = f"(({self.label_col_name}), {self.vector_field})"
+        else:
+            target = f"({self.vector_field})"
         create_index_cql = (
             f"CREATE CUSTOM INDEX IF NOT EXISTS ON {self.table_name} "
-            f"({self.vector_field}) USING 'vector_index' "
+            f"{target} USING 'vector_index' "
             f"WITH OPTIONS = {self.case_config.index_param()}"
         )
         session.execute(create_index_cql)
@@ -367,7 +380,7 @@ class ScyllaDB(VectorDB):
             self._filter_params = (filters.int_value,)
         elif filters.type == FilterOp.StrEqual:
             where = f" WHERE {self.label_col_name} = ?"
-            allow_filtering = " ALLOW FILTERING"
+            allow_filtering = "" if self._use_local_index else " ALLOW FILTERING"
             self._filter_params = (filters.label_value,)
         else:
             msg = f"Unsupported filter for {self.name}: {filters}"

--- a/vectordb_bench/frontend/config/dbCaseConfigs.py
+++ b/vectordb_bench/frontend/config/dbCaseConfigs.py
@@ -2000,6 +2000,13 @@ CaseConfigParamInput_rescoring_ScyllaDB = CaseConfigInput(
     inputConfig={"value": False},
 )
 
+CaseConfigParamInput_index_scope_ScyllaDB = CaseConfigInput(
+    label=CaseConfigParamType.scylladb_index_scope,
+    inputHelp="Use local (partition-level) or global secondary index for label-filter search",
+    inputType=InputType.Option,
+    inputConfig={"options": ["local", "global"]},
+)
+
 LanceDBLoadConfig = [
     CaseConfigParamInput_IndexType_LanceDB,
     CaseConfigParamInput_num_partitions_LanceDB,
@@ -2049,7 +2056,8 @@ ScyllaDBPerformanceConfig = [
     CaseConfigParamInput_ef_search_ScyllaDB,
     CaseConfigParamInput_quantization_ScyllaDB,
     CaseConfigParamInput_oversampling_ScyllaDB,
-    CaseConfigParamInput_rescoring_ScyllaDB
+    CaseConfigParamInput_rescoring_ScyllaDB,
+    CaseConfigParamInput_index_scope_ScyllaDB,
 ]
 
 # Map DB to config

--- a/vectordb_bench/models.py
+++ b/vectordb_bench/models.py
@@ -130,6 +130,7 @@ class CaseConfigParamType(Enum):
     scylladb_quantization = "quantization"
     scylladb_oversampling = "oversampling"
     scylladb_rescoring = "rescoring"
+    scylladb_index_scope = "index_scope"
 
 
 class CustomizedCase(BaseModel):


### PR DESCRIPTION
- Add ScyllaDBIndexScope enum (local/global) to config
- Add index_scope field to ScyllaDBIndexConfig (default: local)
- Add combo box in frontend for index scope selection
- Local index: partition key on label_col, local vector index, no ALLOW FILTERING
- Global index: existing behavior with ALLOW FILTERING