### PR TITLE
Add 'create index after upload' option for ScyllaDB

### DIFF
--- a/vectordb_bench/backend/clients/scylladb/config.py
+++ b/vectordb_bench/backend/clients/scylladb/config.py
@@ -1,4 +1,3 @@
-
 from enum import Enum
 
 from pydantic import BaseModel
@@ -39,6 +38,7 @@ class ScyllaDBIndexConfig(BaseModel, DBCaseConfig):
     rescoring: bool | None = False  # Whether to rescore search result with original vectors
     oversampling: float | None = 1.0  # Search for oversampling * LIMIT results to improve recall
     index_scope: ScyllaDBIndexScope = ScyllaDBIndexScope.LOCAL  # Local vs global secondary index
+    create_index_after_upload: bool = True  # Whether to create the index after data is uploaded
 
     def get_similarity_function_name(self) -> str:
         if self.metric_type == MetricType.COSINE:

--- a/vectordb_bench/backend/clients/scylladb/scylladb.py
+++ b/vectordb_bench/backend/clients/scylladb/scylladb.py
@@ -114,7 +114,8 @@ class ScyllaDB(VectorDB):
                 log.info("%s dropping old table: %s", self.name, self.table_name)
                 session.execute(f"DROP TABLE IF EXISTS {self.table_name}")
                 self._create_table(session)
-                self._create_index(session)
+                if not self.case_config.create_index_after_upload:
+                    self._create_index(session)
 
     # -- authentication & driver detection -----------------------------------
 
@@ -460,5 +461,8 @@ class ScyllaDB(VectorDB):
             time.sleep(poll_interval)
 
     def optimize(self, data_size: int | None = None) -> None:
-        """Wait for index to be fully built before search benchmarks."""
+        """Create index (if deferred) and wait for it to be fully built before search benchmarks."""
+        if self.case_config.create_index_after_upload:
+            session = self._ensure_session()
+            self._create_index(session)
         self._wait_for_index_build()

--- a/vectordb_bench/frontend/config/dbCaseConfigs.py
+++ b/vectordb_bench/frontend/config/dbCaseConfigs.py
@@ -2007,6 +2007,13 @@ CaseConfigParamInput_index_scope_ScyllaDB = CaseConfigInput(
     inputConfig={"options": ["local", "global"]},
 )
 
+CaseConfigParamInput_create_index_after_upload_ScyllaDB = CaseConfigInput(
+    label=CaseConfigParamType.scylladb_create_index_after_upload,
+    inputHelp="Create the vector index after data is uploaded (True) or before upload (False)",
+    inputType=InputType.Bool,
+    inputConfig={"value": True},
+)
+
 LanceDBLoadConfig = [
     CaseConfigParamInput_IndexType_LanceDB,
     CaseConfigParamInput_num_partitions_LanceDB,
@@ -2048,6 +2055,7 @@ AWSOpenSearchPerformanceConfig = [
 ScyllaDBLoadingConfig = [
     CaseConfigParamInput_ef_construction_ScyllaDB,
     CaseConfigParamInput_m_ScyllaDB,
+    CaseConfigParamInput_create_index_after_upload_ScyllaDB,
 ]
 
 ScyllaDBPerformanceConfig = [
@@ -2058,6 +2066,7 @@ ScyllaDBPerformanceConfig = [
     CaseConfigParamInput_oversampling_ScyllaDB,
     CaseConfigParamInput_rescoring_ScyllaDB,
     CaseConfigParamInput_index_scope_ScyllaDB,
+    CaseConfigParamInput_create_index_after_upload_ScyllaDB,
 ]
 
 # Map DB to config

--- a/vectordb_bench/models.py
+++ b/vectordb_bench/models.py
@@ -131,6 +131,7 @@ class CaseConfigParamType(Enum):
     scylladb_oversampling = "oversampling"
     scylladb_rescoring = "rescoring"
     scylladb_index_scope = "index_scope"
+    scylladb_create_index_after_upload = "create_index_after_upload"
 
 
 class CustomizedCase(BaseModel):


### PR DESCRIPTION
Add a boolean config option (default: True) that controls whether the vector index is created after data upload (in optimize) or before upload (in __init__). This allows benchmarking index build on pre-loaded data.

Changes:
- models.py: add scylladb_create_index_after_upload enum member
- config.py: add create_index_after_upload field to ScyllaDBIndexConfig
- scylladb.py: defer index creation to optimize() when enabled
- dbCaseConfigs.py: add Bool combo box to Loading and Performance configs