### PR TITLE
Use prepared statement for index build probe query

### DIFF
--- a/vectordb_bench/backend/clients/scylladb/scylladb.py
+++ b/vectordb_bench/backend/clients/scylladb/scylladb.py
@@ -441,15 +441,16 @@ class ScyllaDB(VectorDB):
         log.info("%s waiting for index build to complete …", self.name)
 
         sample_vector = [0.0] * self.dim
-        probe_cql = (
-            f"SELECT * FROM {self.table_name} "
-            f"ORDER BY {self.vector_field} ANN OF %s LIMIT 1"
+        sample_vector[0] = 1.0  # Avoid all-zero vector which may be rejected by some metrics
+        probe_stmt = session.prepare(
+            f"SELECT {self.id_col_name} FROM {self.table_name} "
+            f"ORDER BY {self.vector_field} ANN OF ? LIMIT 1"
         )
 
         deadline = time.monotonic() + timeout
         while True:
             try:
-                session.execute(probe_cql, (sample_vector,))
+                session.execute(probe_stmt, (sample_vector,))
             except Exception as e:
                 if time.monotonic() >= deadline:
                     msg = f"{self.name}: index not ready after {timeout}s"


### PR DESCRIPTION
Replace raw CQL string with session.prepare() in _wait_for_index_build. Also select only the id column instead of * and use a non-zero sample vector to avoid potential rejection by some distance metrics.