### PR TITLE
New python driver

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,8 @@
 DATASET_LOCAL_DIR="/tmp/vectordb_bench/dataset"
 
 # DROP_OLD = True
+
+# --- ScyllaDB ---
+# SCYLLADB_URI=
+# SCYLLADB_USERNAME=
+# SCYLLADB_PASSWORD=

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ all = [
     "pyvespa",
     "lancedb",
     "mysql-connector-python",
-    "scylla-driver",
+    "scylla @ git+https://github.com/scylladb-zpp-2025-python-rs-driver/python-rs-driver.git",
 ]
 
 qdrant          = [ "qdrant-client" ]
@@ -100,7 +100,7 @@ clickhouse      = [ "clickhouse-connect" ]
 vespa           = [ "pyvespa" ]
 lancedb         = [ "lancedb" ]
 oceanbase       = [ "mysql-connector-python" ]
-scylladb        = [ "scylla-driver" ]
+scylladb        = [ "scylla @ git+https://github.com/scylladb-zpp-2025-python-rs-driver/python-rs-driver.git" ]
 
 [project.urls]
 "repository" = "https://github.com/zilliztech/VectorDBBench"

--- a/tests/test_scylladb.py
+++ b/tests/test_scylladb.py
@@ -217,40 +217,6 @@ class TestScyllaDBInit:
             db._ensure_session()
 
 
-def _make_sync_run():
-    """Create an event loop + a ``_run`` replacement that uses it.
-
-    Returns ``(loop, patched_run)``.  The caller must close the loop and unset
-    it when done (use :func:`_insert_test_context`).
-
-    ``asyncio.gather()`` called outside an async context (Python 3.13) uses
-    ``get_event_loop()``; by setting our own loop we ensure the returned Future
-    belongs to the same loop that ``run_until_complete`` later uses.
-    """
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-
-    def _patched_run(coro_or_future):
-        return loop.run_until_complete(coro_or_future)
-
-    return loop, _patched_run
-
-
-from contextlib import contextmanager
-
-
-@contextmanager
-def _insert_test_context():
-    """Context manager that provides a patched ``_run`` for insert tests."""
-    loop, patched_run = _make_sync_run()
-    try:
-        with patch.object(_scylladb_module, "_run", side_effect=patched_run):
-            yield
-    finally:
-        asyncio.set_event_loop(None)
-        loop.close()
-
-
 class TestScyllaDBInsertEmbeddings:
     """Tests for insert_embeddings() — verifies asyncio.gather pattern."""
 
@@ -274,8 +240,7 @@ class TestScyllaDBInsertEmbeddings:
         embeddings = [[0.1, 0.2, 0.3, 0.4], [0.5, 0.6, 0.7, 0.8]]
         metadata = [1, 2]
 
-        with _insert_test_context():
-            count, err = db.insert_embeddings(embeddings, metadata)
+        count, err = db.insert_embeddings(embeddings, metadata)
 
         assert count == 2
         assert err is None
@@ -290,8 +255,7 @@ class TestScyllaDBInsertEmbeddings:
         metadata = [42]
         labels = ["red"]
 
-        with _insert_test_context():
-            count, err = db.insert_embeddings(embeddings, metadata, labels_data=labels)
+        count, err = db.insert_embeddings(embeddings, metadata, labels_data=labels)
 
         assert count == 1
         assert err is None
@@ -314,8 +278,7 @@ class TestScyllaDBInsertEmbeddings:
         db, session, prep = self._setup_db_with_session()
         session.execute = AsyncMock(side_effect=RuntimeError("connection lost"))
 
-        with _insert_test_context():
-            count, err = db.insert_embeddings([[0.1, 0.2, 0.3, 0.4]], [1])
+        count, err = db.insert_embeddings([[0.1, 0.2, 0.3, 0.4]], [1])
 
         assert count == 0
         assert isinstance(err, Exception)

--- a/tests/test_scylladb.py
+++ b/tests/test_scylladb.py
@@ -1,0 +1,607 @@
+"""Unit tests for the ScyllaDB VectorDB client (python-rs driver).
+
+All driver interactions are mocked — no running ScyllaDB instance is required.
+The ``scylla`` package does not need to be installed; the entire module
+hierarchy is injected into ``sys.modules`` before the client module is loaded.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import sys
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Inject fake ``scylla`` package into sys.modules BEFORE any imports that
+# depend on it (the client module has ``from scylla.enums import …`` etc.)
+# ---------------------------------------------------------------------------
+
+_scylla_mod = ModuleType("scylla")
+_scylla_enums = ModuleType("scylla.enums")
+_scylla_session_builder = ModuleType("scylla.session_builder")
+_scylla_session = ModuleType("scylla.session")
+_scylla_statement = ModuleType("scylla.statement")
+
+# Provide the symbols expected by scylladb.py at import time
+_scylla_enums.Consistency = MagicMock(name="Consistency")
+_scylla_enums.Consistency.One = MagicMock(name="Consistency.One")
+_scylla_session_builder.SessionBuilder = MagicMock(name="SessionBuilder")
+_scylla_session.Session = MagicMock(name="Session")
+_scylla_statement.PreparedStatement = MagicMock(name="PreparedStatement")
+
+for name, mod in {
+    "scylla": _scylla_mod,
+    "scylla.enums": _scylla_enums,
+    "scylla.session_builder": _scylla_session_builder,
+    "scylla.session": _scylla_session,
+    "scylla.statement": _scylla_statement,
+}.items():
+    sys.modules.setdefault(name, mod)
+
+# Force-reload the client module so it picks up the fakes
+import vectordb_bench.backend.clients.scylladb.scylladb as _scylladb_module
+
+importlib.reload(_scylladb_module)
+
+from vectordb_bench.backend.clients.scylladb.scylladb import ScyllaDB, _run
+from vectordb_bench.backend.clients.scylladb.config import (
+    ScyllaDBIndexConfig,
+    ScyllaDBIndexScope,
+)
+from vectordb_bench.backend.clients.api import MetricType
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_db_config(
+    keyspace: str = "test_ks",
+    uris: list[str] | None = None,
+    replication_factor: int = 1,
+) -> dict:
+    return {
+        "keyspace": keyspace,
+        "cluster_uris": uris or ["127.0.0.1"],
+        "replication_factor": replication_factor,
+    }
+
+
+def _make_case_config(**overrides) -> ScyllaDBIndexConfig:
+    defaults = dict(metric_type=MetricType.L2)
+    defaults.update(overrides)
+    return ScyllaDBIndexConfig(**defaults)
+
+
+def _mock_prepared():
+    """Return a mock PreparedStatement whose .with_consistency() returns itself."""
+    prep = MagicMock(name="PreparedStatement")
+    prep.with_consistency.return_value = prep
+    return prep
+
+
+def _mock_session(prepare_rv=None):
+    """Return an AsyncMock Session with .execute() and .prepare() coroutines."""
+    session = AsyncMock(name="Session")
+    session.execute = AsyncMock(return_value=MagicMock())
+    if prepare_rv is None:
+        prepare_rv = _mock_prepared()
+    session.prepare = AsyncMock(return_value=prepare_rv)
+    return session
+
+
+def _mock_session_builder(session):
+    """Return a MagicMock SessionBuilder whose .connect() resolves to *session*."""
+    builder = MagicMock(name="SessionBuilder")
+    builder.connect = AsyncMock(return_value=session)
+    return builder
+
+
+def _build_scylladb(dim=4, drop_old=False, with_scalar_labels=False, **extra):
+    """Construct a ScyllaDB instance with all driver calls mocked.
+
+    Patches SessionBuilder so the constructor's _connect() uses our mock
+    session, and patches _read_credentials to avoid .env lookups.
+    """
+    session = _mock_session()
+    builder = _mock_session_builder(session)
+    case_config = _make_case_config(**extra)
+
+    with (
+        patch.object(
+            _scylladb_module,
+            "SessionBuilder",
+            return_value=builder,
+        ),
+        patch.object(
+            ScyllaDB,
+            "_read_credentials",
+            return_value=(None, None),
+        ),
+    ):
+        db = ScyllaDB(
+            dim=dim,
+            db_config=_make_db_config(),
+            db_case_config=case_config,
+            drop_old=drop_old,
+            with_scalar_labels=with_scalar_labels,
+        )
+
+    return db, session, builder
+
+
+# ===========================================================================
+# Tests
+# ===========================================================================
+
+
+class TestScyllaDBConstruction:
+    """Tests for __init__ / schema setup."""
+
+    def test_basic_construction_no_drop(self):
+        """Constructor with drop_old=False must NOT issue DROP/CREATE statements."""
+        db, session, builder = _build_scylladb(drop_old=False)
+
+        assert db.name == "ScyllaDB"
+        assert db.dim == 4
+        # connect was called once
+        builder.connect.assert_awaited_once()
+        # keyspace creation + USE were called
+        calls = [str(c) for c in session.execute.await_args_list]
+        assert any("CREATE KEYSPACE" in c for c in calls)
+        assert any("USE" in c for c in calls)
+        # no DROP TABLE
+        assert not any("DROP TABLE" in c for c in calls)
+
+    def test_construction_drop_old_creates_table(self):
+        """Constructor with drop_old=True must DROP + CREATE TABLE."""
+        db, session, _builder = _build_scylladb(drop_old=True)
+
+        calls = [str(c) for c in session.execute.await_args_list]
+        assert any("DROP TABLE" in c for c in calls)
+        assert any("CREATE TABLE" in c for c in calls)
+
+    def test_construction_drop_old_creates_index_when_not_deferred(self):
+        """When create_index_after_upload=False, index is created in __init__."""
+        db, session, _builder = _build_scylladb(
+            drop_old=True, create_index_after_upload=False,
+        )
+        calls = [str(c) for c in session.execute.await_args_list]
+        assert any("CREATE CUSTOM INDEX" in c for c in calls)
+
+    def test_construction_drop_old_no_index_when_deferred(self):
+        """When create_index_after_upload=True (default), index is NOT created in __init__."""
+        db, session, _builder = _build_scylladb(
+            drop_old=True, create_index_after_upload=True,
+        )
+        calls = [str(c) for c in session.execute.await_args_list]
+        assert not any("CREATE CUSTOM INDEX" in c for c in calls)
+
+
+class TestScyllaDBInit:
+    """Tests for the init() context-manager lifecycle."""
+
+    def test_init_opens_and_closes_session(self):
+        """init() should open a session and prepare INSERT; exit clears state."""
+        db, session, _builder = _build_scylladb()
+
+        # Before init(), session is None (constructor uses a throwaway session)
+        assert db.session is None
+
+        with (
+            patch.object(
+                type(db), "_build_session_builder",
+                return_value=_mock_session_builder(session),
+            ),
+            patch.object(
+                type(db), "_read_credentials",
+                return_value=(None, None),
+            ),
+        ):
+            with db.init():
+                assert db.session is not None
+                assert db.prepared_insert is not None
+
+            # After exit, state is cleared
+            assert db.session is None
+            assert db.prepared_insert is None
+
+    def test_ensure_session_raises_without_init(self):
+        """_ensure_session must raise when called outside init()."""
+        db, _, _ = _build_scylladb()
+        with pytest.raises(RuntimeError, match="no active session"):
+            db._ensure_session()
+
+
+def _make_sync_run():
+    """Create an event loop + a ``_run`` replacement that uses it.
+
+    Returns ``(loop, patched_run)``.  The caller must close the loop and unset
+    it when done (use :func:`_insert_test_context`).
+
+    ``asyncio.gather()`` called outside an async context (Python 3.13) uses
+    ``get_event_loop()``; by setting our own loop we ensure the returned Future
+    belongs to the same loop that ``run_until_complete`` later uses.
+    """
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
+    def _patched_run(coro_or_future):
+        return loop.run_until_complete(coro_or_future)
+
+    return loop, _patched_run
+
+
+from contextlib import contextmanager
+
+
+@contextmanager
+def _insert_test_context():
+    """Context manager that provides a patched ``_run`` for insert tests."""
+    loop, patched_run = _make_sync_run()
+    try:
+        with patch.object(_scylladb_module, "_run", side_effect=patched_run):
+            yield
+    finally:
+        asyncio.set_event_loop(None)
+        loop.close()
+
+
+class TestScyllaDBInsertEmbeddings:
+    """Tests for insert_embeddings() — verifies asyncio.gather pattern."""
+
+    def _setup_db_with_session(self, with_scalar_labels=False):
+        """Return (db, mock_session) with session + prepared insert wired up."""
+        db, session, _builder = _build_scylladb(
+            with_scalar_labels=with_scalar_labels,
+        )
+        prep = _mock_prepared()
+        db.session = session
+        db.prepared_insert = prep
+        # Reset call counts accumulated during construction
+        session.execute.reset_mock()
+        session.prepare.reset_mock()
+        return db, session, prep
+
+    def test_insert_calls_execute_per_row(self):
+        """Each embedding must produce one session.execute call via gather."""
+        db, session, prep = self._setup_db_with_session()
+
+        embeddings = [[0.1, 0.2, 0.3, 0.4], [0.5, 0.6, 0.7, 0.8]]
+        metadata = [1, 2]
+
+        with _insert_test_context():
+            count, err = db.insert_embeddings(embeddings, metadata)
+
+        assert count == 2
+        assert err is None
+        # Two execute calls (one per row), dispatched via asyncio.gather
+        assert session.execute.await_count == 2
+
+    def test_insert_with_labels(self):
+        """With scalar labels enabled, label data must be passed to execute."""
+        db, session, prep = self._setup_db_with_session(with_scalar_labels=True)
+
+        embeddings = [[0.1, 0.2, 0.3, 0.4]]
+        metadata = [42]
+        labels = ["red"]
+
+        with _insert_test_context():
+            count, err = db.insert_embeddings(embeddings, metadata, labels_data=labels)
+
+        assert count == 1
+        assert err is None
+        session.execute.assert_awaited_once()
+        args = session.execute.await_args
+        # values list should be [key, embedding, label]
+        assert args[0][1] == [42, [0.1, 0.2, 0.3, 0.4], "red"]
+
+    def test_insert_labels_required_when_scalar(self):
+        """Omitting labels_data when with_scalar_labels=True must return error."""
+        db, session, prep = self._setup_db_with_session(with_scalar_labels=True)
+
+        count, err = db.insert_embeddings([[0.1, 0.2, 0.3, 0.4]], [1])
+
+        assert count == 0
+        assert isinstance(err, ValueError)
+
+    def test_insert_returns_error_on_execute_failure(self):
+        """If session.execute raises, error should be captured and returned."""
+        db, session, prep = self._setup_db_with_session()
+        session.execute = AsyncMock(side_effect=RuntimeError("connection lost"))
+
+        with _insert_test_context():
+            count, err = db.insert_embeddings([[0.1, 0.2, 0.3, 0.4]], [1])
+
+        assert count == 0
+        assert isinstance(err, Exception)
+
+
+class TestScyllaDBSearch:
+    """Tests for prepare_filter() + search_embedding()."""
+
+    def _setup_db_with_session(self):
+        db, session, _builder = _build_scylladb()
+        db.session = session
+        return db, session
+
+    def test_prepare_filter_non_filter(self):
+        """NonFilter must prepare a query without WHERE clause."""
+        from vectordb_bench.backend.filter import NonFilter
+
+        db, session = self._setup_db_with_session()
+        db.prepare_filter(NonFilter())
+
+        session.prepare.assert_awaited_once()
+        cql = session.prepare.await_args[0][0]
+        assert "WHERE" not in cql
+        assert "ORDER BY" in cql
+        assert db._filter_params == ()
+
+    def test_prepare_filter_num_ge(self):
+        """NumGE filter must insert WHERE id > ? and ALLOW FILTERING."""
+        from vectordb_bench.backend.filter import IntFilter
+
+        db, session = self._setup_db_with_session()
+        f = IntFilter(int_value=500, filter_rate=0.01)
+        db.prepare_filter(f)
+
+        cql = session.prepare.await_args[0][0]
+        assert "WHERE id > ?" in cql
+        assert "ALLOW FILTERING" in cql
+        assert db._filter_params == (500,)
+
+    def test_prepare_filter_str_equal(self):
+        """StrEqual filter must insert WHERE label = ?."""
+        from vectordb_bench.backend.filter import LabelFilter
+
+        db, session = self._setup_db_with_session()
+        f = LabelFilter(label_percentage=0.05)
+        db.prepare_filter(f)
+
+        cql = session.prepare.await_args[0][0]
+        assert "WHERE filtering_label = ?" in cql
+        assert db._filter_params == (f.label_value,)
+
+    def test_search_embedding_returns_ids(self):
+        """search_embedding must return list of IDs from result rows."""
+        db, session = self._setup_db_with_session()
+
+        # Mock result object with iter_rows returning dicts
+        mock_result = MagicMock()
+        mock_result.iter_rows.return_value = [
+            {"id": 10}, {"id": 20}, {"id": 30},
+        ]
+        session.execute = AsyncMock(return_value=mock_result)
+
+        # Set up prepared_lookup
+        db.prepared_lookup = _mock_prepared()
+        db._filter_params = ()
+
+        ids = db.search_embedding([0.1, 0.2, 0.3, 0.4], k=3)
+
+        assert ids == [10, 20, 30]
+        session.execute.assert_awaited_once()
+
+    def test_search_without_prepare_raises(self):
+        """search_embedding must raise if prepare_filter was not called."""
+        db, session = self._setup_db_with_session()
+
+        with pytest.raises(RuntimeError, match="prepared_lookup is not set"):
+            db.search_embedding([0.1, 0.2, 0.3, 0.4])
+
+    def test_search_with_filter_params(self):
+        """Filter params must be prepended to the execute values."""
+        db, session = self._setup_db_with_session()
+
+        mock_result = MagicMock()
+        mock_result.iter_rows.return_value = [{"id": 5}]
+        session.execute = AsyncMock(return_value=mock_result)
+
+        db.prepared_lookup = _mock_prepared()
+        db._filter_params = (100,)
+
+        query = [0.1, 0.2, 0.3, 0.4]
+        ids = db.search_embedding(query, k=10)
+
+        args = session.execute.await_args
+        values = args[0][1]
+        # first element is filter param, then query vector, then k
+        assert values == [100, query, 10]
+        assert ids == [5]
+
+
+class TestScyllaDBOptimize:
+    """Tests for optimize() / _wait_for_index_build()."""
+
+    def _setup_db_with_session(self):
+        db, session, _builder = _build_scylladb()
+        db.session = session
+        return db, session
+
+    def test_optimize_creates_index_when_deferred(self):
+        """optimize() must CREATE INDEX when create_index_after_upload is True."""
+        db, session = self._setup_db_with_session()
+        assert db.case_config.create_index_after_upload is True
+
+        # Make probe query succeed immediately
+        session.execute = AsyncMock(return_value=MagicMock())
+
+        db.optimize()
+
+        calls = [str(c) for c in session.execute.await_args_list]
+        assert any("CREATE CUSTOM INDEX" in c for c in calls)
+
+    def test_optimize_skips_index_when_not_deferred(self):
+        """optimize() must NOT CREATE INDEX when create_index_after_upload is False."""
+        db, session, _builder = _build_scylladb(create_index_after_upload=False)
+        db.session = session
+
+        session.execute = AsyncMock(return_value=MagicMock())
+
+        db.optimize()
+
+        calls = [str(c) for c in session.execute.await_args_list]
+        assert not any("CREATE CUSTOM INDEX" in c for c in calls)
+
+    def test_wait_for_index_build_succeeds_immediately(self):
+        """If probe query succeeds, _wait_for_index_build returns immediately."""
+        db, session = self._setup_db_with_session()
+        session.execute = AsyncMock(return_value=MagicMock())
+
+        db._wait_for_index_build(timeout=5.0)
+
+        # Probe was called at least once
+        assert session.execute.await_count >= 1
+
+    def test_wait_for_index_build_retries_then_succeeds(self):
+        """Probe should retry on failure, then succeed."""
+        db, session = self._setup_db_with_session()
+
+        # Fail twice, then succeed
+        session.execute = AsyncMock(
+            side_effect=[RuntimeError("not ready"), RuntimeError("not ready"), MagicMock()]
+        )
+
+        with patch.object(_scylladb_module.time, "sleep"):
+            db._wait_for_index_build(timeout=60.0, poll_interval=0.0)
+
+        assert session.execute.await_count == 3
+
+    def test_wait_for_index_build_timeout(self):
+        """If index never becomes ready, TimeoutError is raised."""
+        db, session = self._setup_db_with_session()
+        session.execute = AsyncMock(side_effect=RuntimeError("not ready"))
+
+        with patch.object(_scylladb_module.time, "sleep"):
+            with pytest.raises(TimeoutError, match="index not ready"):
+                db._wait_for_index_build(timeout=0.0, poll_interval=0.0)
+
+
+class TestScyllaDBSchemaVariants:
+    """Tests for table/index creation with different label/index scope configs."""
+
+    def test_table_with_scalar_labels_global_index(self):
+        """With scalar labels + GLOBAL scope, PK should be (id, label)."""
+        db, session, _ = _build_scylladb(
+            drop_old=True,
+            with_scalar_labels=True,
+            index_scope=ScyllaDBIndexScope.GLOBAL,
+        )
+
+        calls = [str(c) for c in session.execute.await_args_list]
+        create_table = [c for c in calls if "CREATE TABLE" in c]
+        assert len(create_table) == 1
+        assert "PRIMARY KEY (id, filtering_label)" in create_table[0]
+
+    def test_table_with_scalar_labels_local_index(self):
+        """With scalar labels + LOCAL scope, PK should be (label, id)."""
+        db, session, _ = _build_scylladb(
+            drop_old=True,
+            with_scalar_labels=True,
+            index_scope=ScyllaDBIndexScope.LOCAL,
+        )
+
+        calls = [str(c) for c in session.execute.await_args_list]
+        create_table = [c for c in calls if "CREATE TABLE" in c]
+        assert len(create_table) == 1
+        assert "PRIMARY KEY (filtering_label, id)" in create_table[0]
+
+    def test_table_without_scalar_labels(self):
+        """Without scalar labels, PK should be (id) only."""
+        db, session, _ = _build_scylladb(
+            drop_old=True,
+            with_scalar_labels=False,
+        )
+
+        calls = [str(c) for c in session.execute.await_args_list]
+        create_table = [c for c in calls if "CREATE TABLE" in c]
+        assert len(create_table) == 1
+        assert "PRIMARY KEY (id)" in create_table[0]
+
+    def test_index_target_with_local_scope(self):
+        """LOCAL scope index target should include partition key column."""
+        db, session, _ = _build_scylladb(
+            drop_old=True,
+            with_scalar_labels=True,
+            index_scope=ScyllaDBIndexScope.LOCAL,
+            create_index_after_upload=False,
+        )
+
+        calls = [str(c) for c in session.execute.await_args_list]
+        create_index = [c for c in calls if "CREATE CUSTOM INDEX" in c]
+        assert len(create_index) == 1
+        assert "((filtering_label), vector)" in create_index[0]
+
+    def test_index_target_with_global_scope(self):
+        """GLOBAL scope index target should be just (vector)."""
+        db, session, _ = _build_scylladb(
+            drop_old=True,
+            with_scalar_labels=True,
+            index_scope=ScyllaDBIndexScope.GLOBAL,
+            create_index_after_upload=False,
+        )
+
+        calls = [str(c) for c in session.execute.await_args_list]
+        create_index = [c for c in calls if "CREATE CUSTOM INDEX" in c]
+        assert len(create_index) == 1
+        assert "(vector)" in create_index[0]
+        assert "((filtering_label)" not in create_index[0]
+
+
+class TestScyllaDBNeedNormalize:
+    """Test need_normalize_cosine behaviour."""
+
+    def test_need_normalize_cosine_returns_true(self):
+        db, _, _ = _build_scylladb()
+        assert db.need_normalize_cosine() is True
+
+
+class TestScyllaDBCredentials:
+    """Test credential-reading logic."""
+
+    def test_read_credentials_both_set(self):
+        with patch("environs.Env") as MockEnv:
+            env_instance = MagicMock()
+            env_instance.read_env = MagicMock()
+            env_instance.side_effect = lambda key, default=None: {
+                "SCYLLADB_USERNAME": "admin",
+                "SCYLLADB_PASSWORD": "secret",
+            }.get(key, default)
+            MockEnv.return_value = env_instance
+
+            username, password = ScyllaDB._read_credentials()
+            assert username == "admin"
+            assert password == "secret"
+
+    def test_read_credentials_none_set(self):
+        with patch("environs.Env") as MockEnv:
+            env_instance = MagicMock()
+            env_instance.read_env = MagicMock()
+            env_instance.side_effect = lambda key, default=None: default
+            MockEnv.return_value = env_instance
+
+            username, password = ScyllaDB._read_credentials()
+            assert username is None
+            assert password is None
+
+
+class TestRunHelper:
+    """Tests for the _run() async-to-sync bridge."""
+
+    def test_run_executes_coroutine(self):
+        async def coro():
+            return 42
+
+        assert _run(coro()) == 42
+
+    def test_run_propagates_exception(self):
+        async def failing():
+            raise ValueError("boom")
+
+        with pytest.raises(ValueError, match="boom"):
+            _run(failing())

--- a/vectordb_bench/backend/clients/scylladb/scylladb.py
+++ b/vectordb_bench/backend/clients/scylladb/scylladb.py
@@ -341,24 +341,27 @@ class ScyllaDB(VectorDB):
         session = self._ensure_session()
         assert self.prepared_insert is not None, "prepared_insert not initialized"
 
-        try:
+        async def _insert_batch():
             if self.with_scalar_labels:
                 if labels_data is None:
                     raise ValueError(
                         "labels_data is required when with_scalar_labels is True"
                     )
-                coroutines = [
+                coros = [
                     session.execute(self.prepared_insert, [key, embedding, label])
                     for key, embedding, label in zip(
                         metadata, embeddings, labels_data, strict=True
                     )
                 ]
             else:
-                coroutines = [
+                coros = [
                     session.execute(self.prepared_insert, [key, embedding])
                     for key, embedding in zip(metadata, embeddings, strict=True)
                 ]
-            _run(asyncio.gather(*coroutines))
+            await asyncio.gather(*coros)
+
+        try:
+            _run(_insert_batch())
         except Exception as e:
             log.warning("%s failed to insert data: %s", self.name, e)
             return 0, e

--- a/vectordb_bench/backend/clients/scylladb/scylladb.py
+++ b/vectordb_bench/backend/clients/scylladb/scylladb.py
@@ -1,18 +1,19 @@
-"""Wrapper around the ScyllaDB vector database for VectorDB benchmarks."""
+"""Wrapper around the ScyllaDB vector database for VectorDB benchmarks.
+
+Uses the new ``scylla`` Python-rs driver (async, Rust-backed) instead of the
+legacy ``cassandra-driver`` / ``scylla-driver``.
+"""
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, ClassVar, Final
 
-import cassandra
-from cassandra import ConsistencyLevel
-from cassandra.auth import PlainTextAuthProvider
-from cassandra.cluster import Cluster, Session
-from cassandra.policies import AddressTranslator as _BaseAddressTranslator
-from cassandra.query import BatchStatement, BatchType, PreparedStatement
+from scylla.enums import Consistency
+from scylla.session_builder import SessionBuilder
 
 from vectordb_bench.backend.filter import Filter, FilterOp
 
@@ -21,6 +22,10 @@ from .config import ScyllaDBIndexScope
 
 if TYPE_CHECKING:
     from collections.abc import Generator, Sequence
+
+    from scylla.session import Session
+    from scylla.statement import PreparedStatement
+
     from .config import ScyllaDBIndexConfig
 
 __all__ = ["ScyllaDB"]
@@ -30,28 +35,29 @@ log = logging.getLogger(__name__)
 _INDEX_POLL_INTERVAL_SEC: Final[float] = 1.0
 _INDEX_BUILD_TIMEOUT_SEC: Final[float] = 3600.0
 
+# Default CQL native transport port
+_DEFAULT_PORT: Final[int] = 9042
 
-class _ContactPointTranslator(_BaseAddressTranslator):
-    """Translate discovered node addresses back to a known contact point.
 
-    When ScyllaDB runs inside Docker the node may broadcast its internal
-    container IP (e.g. ``172.18.0.2``) which is unreachable from the host.
-    This translator maps any address that is *not* one of the original
-    contact points back to the first contact point, keeping the driver
-    connected to reachable addresses.
+def _run(coro):
+    """Run an async coroutine from synchronous code.
+
+    Tries to use the current running loop if available (and schedules via
+    a thread), otherwise falls back to ``asyncio.run()``.
     """
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
 
-    def __init__(self, contact_points: list[str]) -> None:
-        self._known = set(contact_points)
-        self._default = contact_points[0]
+    if loop is not None and loop.is_running():
+        # We're inside an existing event loop (e.g. Jupyter, Streamlit).
+        # Cannot call asyncio.run(); run in a new thread instead.
+        import concurrent.futures
 
-    def translate(self, addr: str) -> str:
-        if addr in self._known:
-            return addr
-        log.debug(
-            "Translating discovered address %s -> %s", addr, self._default
-        )
-        return self._default
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            return pool.submit(asyncio.run, coro).result()
+    return asyncio.run(coro)
 
 
 class ScyllaDB(VectorDB):
@@ -59,6 +65,9 @@ class ScyllaDB(VectorDB):
 
     Manages connection lifecycle, schema creation, data ingestion,
     and ANN search against a ScyllaDB cluster with vector-search support.
+
+    This implementation uses the new async Python-rs driver from
+    ``scylladb-zpp-2025-python-rs-driver/python-rs-driver``.
     """
 
     supported_filter_types: ClassVar[list[FilterOp]] = [
@@ -92,110 +101,94 @@ class ScyllaDB(VectorDB):
         self.vector_field = vector_field
         self.with_scalar_labels = with_scalar_labels
 
-        self.auth_provider: PlainTextAuthProvider | None = self._build_auth_provider()
-
-        # Mutable state — set by init() / prepare_filter()
-        self.cluster: Cluster | None = None
+        # Mutable state -- set by init() / prepare_filter()
         self.session: Session | None = None
         self.prepared_insert: PreparedStatement | None = None
         self.prepared_lookup: PreparedStatement | None = None
         self._filter_params: tuple[object, ...] = ()
 
         log.info(
-            "%s using %s version of %s driver.",
+            "%s using python-rs (Rust-backed) driver.",
             self.name,
-            cassandra.__version__,
-            self._get_driver_provider(),
         )
         log.info("%s index params: %s", self.name, self.case_config.index_param())
 
-        with self._connect() as session:
-            if drop_old:
-                log.info("%s dropping old table: %s", self.name, self.table_name)
-                session.execute(f"DROP TABLE IF EXISTS {self.table_name}")
-                self._create_table(session)
-                if not self.case_config.create_index_after_upload:
-                    self._create_index(session)
+        async def _setup():
+            session = await self._connect()
+            try:
+                if drop_old:
+                    log.info("%s dropping old table: %s", self.name, self.table_name)
+                    await session.execute(f"DROP TABLE IF EXISTS {self.table_name}")
+                    await self._create_table(session)
+                    if not self.case_config.create_index_after_upload:
+                        await self._create_index(session)
+            finally:
+                # The python-rs driver session has no explicit shutdown;
+                # just let it go out of scope.
+                pass
 
-    # -- authentication & driver detection -----------------------------------
+        _run(_setup())
+
+    # -- authentication helpers -----------------------------------------------
 
     @staticmethod
-    def _build_auth_provider(
-        env_path: str = ".env",
-    ) -> PlainTextAuthProvider | None:
-        """Build authentication provider from environment variables.
+    def _read_credentials(env_path: str = ".env") -> tuple[str | None, str | None]:
+        """Read ScyllaDB credentials from environment.
 
-        Reads ``SCYLLADB_USERNAME`` and ``SCYLLADB_PASSWORD`` from a local
-        ``.env`` file (if present).  Returns ``None`` when neither variable is
-        set, and logs a warning when only one of the two is provided.
-
-        Args:
-            env_path: Path to the ``.env`` file.  Defaults to ``".env"``.
+        Returns ``(username, password)``; either or both may be ``None``.
         """
-        import environs  # optional dependency — imported lazily
+        import environs  # optional dependency -- imported lazily
 
         env = environs.Env()
         env.read_env(path=env_path, recurse=False)
         username: str | None = env("SCYLLADB_USERNAME", default=None)
         password: str | None = env("SCYLLADB_PASSWORD", default=None)
 
-        if username and password:
-            return PlainTextAuthProvider(username, password)
-        if username or password:
+        if (username is None) != (password is None):
             log.warning(
                 "Only one of SCYLLADB_USERNAME / SCYLLADB_PASSWORD is set; "
                 "authentication may fail."
             )
-        return None
-
-    @staticmethod
-    def _get_driver_provider() -> str:
-        """Detect whether the ScyllaDB-optimized or standard Cassandra driver is in use."""
-        try:
-            from cassandra.tablets import Tablet  # noqa: F401
-        except ImportError:
-            return "Cassandra"
-        else:
-            return "ScyllaDB"
+        return username, password
 
     # -- connection helpers ---------------------------------------------------
 
-    def _build_cluster(self, contact_points: list[str]) -> Cluster:
-        """Create a :class:`Cluster` with address translation enabled."""
-        return Cluster(
-            contact_points,
-            auth_provider=self.auth_provider,
-            address_translator=_ContactPointTranslator(contact_points),
-        )
+    def _build_session_builder(self, contact_points: list[str]) -> SessionBuilder:
+        """Create a :class:`SessionBuilder` for the configured cluster."""
+        # The python-rs driver's SessionBuilder does not support auth yet.
+        # Credentials are read but only logged as a warning for now.
+        username, password = self._read_credentials()
+        if username and password:
+            log.warning(
+                "%s: python-rs driver does not yet support authentication; "
+                "credentials are ignored.",
+                self.name,
+            )
+        return SessionBuilder(contact_points, _DEFAULT_PORT)
 
-    @contextmanager
-    def _connect(self, keyspace: str | None = None) -> Generator[Session, None, None]:
-        """Open a short-lived cluster connection and guarantee shutdown.
+    async def _connect(self, keyspace: str | None = None) -> Session:
+        """Open a connection returning the async Session.
 
         If *keyspace* is ``None`` the configured keyspace is created (if
-        needed) and set on the returned session automatically.
+        needed) and selected on the session automatically.
         """
         uri = self.db_config["cluster_uris"]
         ks = keyspace or self.db_config["keyspace"]
 
-        cluster = self._build_cluster(uri)
+        builder = self._build_session_builder(uri)
         log.info("%s connecting to cluster at %s", self.name, uri)
-        session = cluster.connect()
-        log.info("%s shard awareness: %s", self.name, cluster.is_shard_aware())
+        session = await builder.connect()
 
-        try:
-            if keyspace is None:
-                self._create_keyspace(session, ks)
-            session.set_keyspace(ks)
-            yield session
-        finally:
-            cluster.shutdown()
+        if keyspace is None:
+            await self._create_keyspace(session, ks)
+        await session.execute(f"USE {ks}")
+        return session
 
     def _ensure_session(self) -> Session:
         """Return the active session or raise if ``init()`` was not called."""
         if self.session is None:
             msg = (
-                f"{self.name}: no active session — "
+                f"{self.name}: no active session -- "
                 "wrap operations inside `with self.init():`"
             )
             raise RuntimeError(msg)
@@ -211,20 +204,20 @@ class ScyllaDB(VectorDB):
             and self.case_config.index_scope == ScyllaDBIndexScope.LOCAL
         )
 
-    def _create_keyspace(self, session: Session, keyspace: str) -> None:
+    async def _create_keyspace(self, session: Session, keyspace: str) -> None:
         """Create keyspace if it does not exist."""
         log.info("%s creating keyspace: %s", self.name, keyspace)
         replication_factor = self.db_config.get("replication_factor", 1)
         # Tablets require NetworkTopologyStrategy; SimpleStrategy is not supported.
         strategy = "NetworkTopologyStrategy"
-        session.execute(
+        await session.execute(
             f"CREATE KEYSPACE IF NOT EXISTS {keyspace} "
             f"WITH replication = {{'class': '{strategy}', "
             f"'replication_factor': '{replication_factor}'}} "
             f"AND tablets = {{'enabled': 'true'}}"
         )
 
-    def _create_table(self, session: Session) -> None:
+    async def _create_table(self, session: Session) -> None:
         """Create table for vector storage."""
         if self._use_local_index:
             pk = f"PRIMARY KEY ({self.label_col_name}, {self.id_col_name})"
@@ -245,10 +238,10 @@ class ScyllaDB(VectorDB):
             f"  {pk}"
             f")"
         )
-        session.execute(create_table_cql)
+        await session.execute(create_table_cql)
         log.info("%s created table: %s", self.name, self.table_name)
 
-    def _create_index(self, session: Session) -> None:
+    async def _create_index(self, session: Session) -> None:
         """Create vector search index on the table."""
         if self._use_local_index:
             target = f"(({self.label_col_name}), {self.vector_field})"
@@ -259,7 +252,7 @@ class ScyllaDB(VectorDB):
             f"{target} USING 'vector_index' "
             f"WITH OPTIONS = {self.case_config.index_param()}"
         )
-        session.execute(create_index_cql)
+        await session.execute(create_index_cql)
         log.info("%s created index on: %s", self.name, self.table_name)
 
     # -- lifecycle (per-process) ---------------------------------------------
@@ -275,11 +268,16 @@ class ScyllaDB(VectorDB):
                 db.insert_embeddings(...)
                 db.search_embedding(...)
         """
-        uri = self.db_config["cluster_uris"]
-        keyspace = self.db_config["keyspace"]
-        self.cluster = self._build_cluster(uri)
-        self.session = self.cluster.connect(keyspace)
 
+        async def _open():
+            uri = self.db_config["cluster_uris"]
+            keyspace = self.db_config["keyspace"]
+            builder = self._build_session_builder(uri)
+            session = await builder.connect()
+            await session.execute(f"USE {keyspace}")
+            return session
+
+        self.session = _run(_open())
         self._prepare_insert_statement()
 
         try:
@@ -288,10 +286,8 @@ class ScyllaDB(VectorDB):
             self._reset_session_state()
 
     def _reset_session_state(self) -> None:
-        """Shut down the cluster and clear all per-session state."""
-        if self.cluster is not None:
-            self.cluster.shutdown()
-        self.cluster = None
+        """Clear all per-session state."""
+        # The python-rs driver session has no explicit shutdown.
         self.session = None
         self.prepared_insert = None
         self.prepared_lookup = None
@@ -308,9 +304,13 @@ class ScyllaDB(VectorDB):
             columns = f"{self.id_col_name}, {self.vector_field}"
             placeholders = "?, ?"
 
-        self.prepared_insert = session.prepare(
-            f"INSERT INTO {self.table_name} ({columns}) VALUES ({placeholders})"
+        prepared = _run(
+            session.prepare(
+                f"INSERT INTO {self.table_name} ({columns}) VALUES ({placeholders})"
+            )
         )
+        # Set consistency ONE on the prepared statement
+        self.prepared_insert = prepared.with_consistency(Consistency.One)
 
     # -- data operations -----------------------------------------------------
 
@@ -325,7 +325,10 @@ class ScyllaDB(VectorDB):
         labels_data: Sequence[str] | None = None,
         **kwargs,
     ) -> tuple[int, Exception | None]:
-        """Insert embeddings into ScyllaDB.
+        """Insert embeddings into ScyllaDB using asyncio.gather for concurrency.
+
+        Instead of batch statements, each row is inserted as a separate
+        async execute call, gathered concurrently via ``asyncio.gather``.
 
         Args:
             embeddings: Vectors to insert.
@@ -339,23 +342,23 @@ class ScyllaDB(VectorDB):
         assert self.prepared_insert is not None, "prepared_insert not initialized"
 
         try:
-            batch = BatchStatement(
-                consistency_level=ConsistencyLevel.ONE,
-                batch_type=BatchType.UNLOGGED,
-            )
             if self.with_scalar_labels:
                 if labels_data is None:
                     raise ValueError(
                         "labels_data is required when with_scalar_labels is True"
                     )
-                for key, embedding, label in zip(
-                    metadata, embeddings, labels_data, strict=True
-                ):
-                    batch.add(self.prepared_insert, (key, embedding, label))
+                coroutines = [
+                    session.execute(self.prepared_insert, [key, embedding, label])
+                    for key, embedding, label in zip(
+                        metadata, embeddings, labels_data, strict=True
+                    )
+                ]
             else:
-                for key, embedding in zip(metadata, embeddings, strict=True):
-                    batch.add(self.prepared_insert, (key, embedding))
-            session.execute(batch)
+                coroutines = [
+                    session.execute(self.prepared_insert, [key, embedding])
+                    for key, embedding in zip(metadata, embeddings, strict=True)
+                ]
+            _run(asyncio.gather(*coroutines))
         except Exception as e:
             log.warning("%s failed to insert data: %s", self.name, e)
             return 0, e
@@ -387,12 +390,15 @@ class ScyllaDB(VectorDB):
             msg = f"Unsupported filter for {self.name}: {filters}"
             raise ValueError(msg)
 
-        self.prepared_lookup = session.prepare(
-            f"SELECT {self.id_col_name} FROM {self.table_name}"
-            f"{where} "
-            f"ORDER BY {self.vector_field} ANN OF ? LIMIT ?"
-            f"{allow_filtering}"
+        prepared = _run(
+            session.prepare(
+                f"SELECT {self.id_col_name} FROM {self.table_name}"
+                f"{where} "
+                f"ORDER BY {self.vector_field} ANN OF ? LIMIT ?"
+                f"{allow_filtering}"
+            )
         )
+        self.prepared_lookup = prepared
 
     def search_embedding(
         self,
@@ -415,14 +421,18 @@ class ScyllaDB(VectorDB):
         session = self._ensure_session()
         if self.prepared_lookup is None:
             msg = (
-                f"{self.name}: prepared_lookup is not set — "
+                f"{self.name}: prepared_lookup is not set -- "
                 "call prepare_filter() before searching"
             )
             raise RuntimeError(msg)
-        rows = session.execute(
-            self.prepared_lookup, (*self._filter_params, query, k)
+
+        result = _run(
+            session.execute(
+                self.prepared_lookup,
+                list(self._filter_params) + [query, k],
+            )
         )
-        return [row[0] for row in rows] if rows else []
+        return [row[self.id_col_name] for row in result.iter_rows()] if result else []
 
     # -- optimisation --------------------------------------------------------
 
@@ -438,19 +448,19 @@ class ScyllaDB(VectorDB):
             poll_interval: Seconds between successive probe queries.
         """
         session = self._ensure_session()
-        log.info("%s waiting for index build to complete …", self.name)
+        log.info("%s waiting for index build to complete ...", self.name)
 
         sample_vector = [0.0] * self.dim
         sample_vector[0] = 1.0  # Avoid all-zero vector which may be rejected by some metrics
-        probe_stmt = session.prepare(
-            f"SELECT {self.id_col_name} FROM {self.table_name} "
+        probe_cql = (
+            f"SELECT * FROM {self.table_name} "
             f"ORDER BY {self.vector_field} ANN OF ? LIMIT 1"
         )
 
         deadline = time.monotonic() + timeout
         while True:
             try:
-                session.execute(probe_stmt, (sample_vector,))
+                _run(session.execute(probe_cql, [sample_vector]))
             except Exception as e:
                 if time.monotonic() >= deadline:
                     msg = f"{self.name}: index not ready after {timeout}s"
@@ -465,5 +475,5 @@ class ScyllaDB(VectorDB):
         """Create index (if deferred) and wait for it to be fully built before search benchmarks."""
         if self.case_config.create_index_after_upload:
             session = self._ensure_session()
-            self._create_index(session)
+            _run(self._create_index(session))
         self._wait_for_index_build()

--- a/vectordb_bench/backend/clients/scylladb/scylladb.py
+++ b/vectordb_bench/backend/clients/scylladb/scylladb.py
@@ -145,6 +145,17 @@ class ScyllaDB(VectorDB):
 
         _run(_setup())
 
+    # -- environment helpers --------------------------------------------------
+
+    @staticmethod
+    def _load_env(env_path: str = ".env") -> "environs.Env":
+        """Load environment variables from *env_path* and return the Env instance."""
+        import environs  # optional dependency -- imported lazily
+
+        env = environs.Env()
+        env.read_env(path=env_path, recurse=False)
+        return env
+
     # -- authentication helpers -----------------------------------------------
 
     @staticmethod
@@ -153,10 +164,7 @@ class ScyllaDB(VectorDB):
 
         Returns ``(username, password)``; either or both may be ``None``.
         """
-        import environs  # optional dependency -- imported lazily
-
-        env = environs.Env()
-        env.read_env(path=env_path, recurse=False)
+        env = ScyllaDB._load_env(env_path)
         username: str | None = env("SCYLLADB_USERNAME", default=None)
         password: str | None = env("SCYLLADB_PASSWORD", default=None)
 
@@ -166,6 +174,16 @@ class ScyllaDB(VectorDB):
                 "authentication may fail."
             )
         return username, password
+
+    @staticmethod
+    def _read_env_uri(env_path: str = ".env") -> str | None:
+        """Read ScyllaDB URI from environment.
+
+        Returns the value of ``SCYLLADB_URI`` if set, otherwise ``None``.
+        The value may be a single host or comma-separated contact points.
+        """
+        env = ScyllaDB._load_env(env_path)
+        return env("SCYLLADB_URI", default=None)
 
     # -- connection helpers ---------------------------------------------------
 
@@ -191,7 +209,11 @@ class ScyllaDB(VectorDB):
         If *keyspace* is ``None`` the configured keyspace is created (if
         needed) and selected on the session automatically.
         """
-        uri = self.db_config["cluster_uris"]
+        env_uri = self._read_env_uri()
+        if env_uri is not None:
+            uri = env_uri.split(",")
+        else:
+            uri = self.db_config["cluster_uris"]
         ks = keyspace or self.db_config["keyspace"]
 
         builder = self._build_session_builder(uri)

--- a/vectordb_bench/backend/clients/scylladb/scylladb.py
+++ b/vectordb_bench/backend/clients/scylladb/scylladb.py
@@ -8,11 +8,13 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import threading
 import time
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, ClassVar, Final
 
 from scylla.enums import Consistency
+from scylla.execution_profile import ExecutionProfile
 from scylla.session_builder import SessionBuilder
 
 from vectordb_bench.backend.filter import Filter, FilterOp
@@ -52,7 +54,16 @@ def _run(coro):
 
     if loop is not None and loop.is_running():
         # We're inside an existing event loop (e.g. Jupyter, Streamlit).
-        # Cannot call asyncio.run(); run in a new thread instead.
+        # Cannot call asyncio.run() because it would try to create a new
+        # event loop on this thread, which is forbidden while one is already
+        # running.  Instead, spawn a *single* worker thread that has no
+        # running loop and call asyncio.run(coro) there.
+        #
+        # max_workers=1 is intentional: we only ever submit one task, so the
+        # pool exists solely to escape the current thread's event loop.  All
+        # real concurrency (e.g. asyncio.gather inside the coroutine) happens
+        # within the fresh event loop that asyncio.run() creates on that
+        # single thread.
         import concurrent.futures
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
@@ -106,6 +117,11 @@ class ScyllaDB(VectorDB):
         self.prepared_insert: PreparedStatement | None = None
         self.prepared_lookup: PreparedStatement | None = None
         self._filter_params: tuple[object, ...] = ()
+
+        # Persistent event loop for the init() context – avoids the cost
+        # of creating / tearing down a loop on every _run() call.
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._loop_thread: threading.Thread | None = None
 
         log.info(
             "%s using python-rs (Rust-backed) driver.",
@@ -164,7 +180,10 @@ class ScyllaDB(VectorDB):
                 "credentials are ignored.",
                 self.name,
             )
-        return SessionBuilder(contact_points, _DEFAULT_PORT)
+        # Default to Consistency.One for all statements – sufficient for
+        # benchmarking and avoids the latency of LocalQuorum.
+        profile = ExecutionProfile(consistency=Consistency.One)
+        return SessionBuilder(contact_points, _DEFAULT_PORT, execution_profile=profile)
 
     async def _connect(self, keyspace: str | None = None) -> Session:
         """Open a connection returning the async Session.
@@ -257,6 +276,39 @@ class ScyllaDB(VectorDB):
 
     # -- lifecycle (per-process) ---------------------------------------------
 
+    # -- persistent event loop helpers ----------------------------------------
+
+    def _start_loop(self) -> None:
+        """Spin up a background thread running a persistent event loop.
+
+        All async driver calls within an ``init()`` context are dispatched
+        to this loop via :pymethod:`_run_async`, avoiding the overhead of
+        ``asyncio.run()`` (which creates *and* destroys a loop each time).
+        """
+        self._loop = asyncio.new_event_loop()
+        self._loop_thread = threading.Thread(
+            target=self._loop.run_forever,
+            daemon=True,
+            name="scylladb-event-loop",
+        )
+        self._loop_thread.start()
+
+    def _stop_loop(self) -> None:
+        """Shut down the persistent event loop and its thread."""
+        if self._loop is not None:
+            self._loop.call_soon_threadsafe(self._loop.stop)
+        if self._loop_thread is not None:
+            self._loop_thread.join(timeout=10.0)
+        self._loop = None
+        self._loop_thread = None
+
+    def _run_async(self, coro):
+        """Schedule *coro* on the persistent loop, or fall back to ``_run``."""
+        loop = self._loop
+        if loop is not None and loop.is_running():
+            return asyncio.run_coroutine_threadsafe(coro, loop).result()
+        return _run(coro)
+
     @contextmanager
     def init(self) -> Generator[None, None, None]:
         """Create and destroy connections to the database.
@@ -268,6 +320,7 @@ class ScyllaDB(VectorDB):
                 db.insert_embeddings(...)
                 db.search_embedding(...)
         """
+        self._start_loop()
 
         async def _open():
             uri = self.db_config["cluster_uris"]
@@ -277,7 +330,7 @@ class ScyllaDB(VectorDB):
             await session.execute(f"USE {keyspace}")
             return session
 
-        self.session = _run(_open())
+        self.session = self._run_async(_open())
         self._prepare_insert_statement()
 
         try:
@@ -292,6 +345,7 @@ class ScyllaDB(VectorDB):
         self.prepared_insert = None
         self.prepared_lookup = None
         self._filter_params = ()
+        self._stop_loop()
 
     def _prepare_insert_statement(self) -> None:
         """Prepare the CQL INSERT statement for the current session."""
@@ -304,7 +358,7 @@ class ScyllaDB(VectorDB):
             columns = f"{self.id_col_name}, {self.vector_field}"
             placeholders = "?, ?"
 
-        prepared = _run(
+        prepared = self._run_async(
             session.prepare(
                 f"INSERT INTO {self.table_name} ({columns}) VALUES ({placeholders})"
             )
@@ -361,7 +415,7 @@ class ScyllaDB(VectorDB):
             await asyncio.gather(*coros)
 
         try:
-            _run(_insert_batch())
+            self._run_async(_insert_batch())
         except Exception as e:
             log.warning("%s failed to insert data: %s", self.name, e)
             return 0, e
@@ -393,7 +447,7 @@ class ScyllaDB(VectorDB):
             msg = f"Unsupported filter for {self.name}: {filters}"
             raise ValueError(msg)
 
-        prepared = _run(
+        prepared = self._run_async(
             session.prepare(
                 f"SELECT {self.id_col_name} FROM {self.table_name}"
                 f"{where} "
@@ -401,7 +455,7 @@ class ScyllaDB(VectorDB):
                 f"{allow_filtering}"
             )
         )
-        self.prepared_lookup = prepared
+        self.prepared_lookup = prepared.with_consistency(Consistency.One)
 
     def search_embedding(
         self,
@@ -429,7 +483,7 @@ class ScyllaDB(VectorDB):
             )
             raise RuntimeError(msg)
 
-        result = _run(
+        result = self._run_async(
             session.execute(
                 self.prepared_lookup,
                 list(self._filter_params) + [query, k],
@@ -459,11 +513,13 @@ class ScyllaDB(VectorDB):
             f"SELECT * FROM {self.table_name} "
             f"ORDER BY {self.vector_field} ANN OF ? LIMIT 1"
         )
+        # Prepare once to avoid repeated server-side parsing in the poll loop.
+        prepared_probe = self._run_async(session.prepare(probe_cql))
 
         deadline = time.monotonic() + timeout
         while True:
             try:
-                _run(session.execute(probe_cql, [sample_vector]))
+                self._run_async(session.execute(prepared_probe, [sample_vector]))
             except Exception as e:
                 if time.monotonic() >= deadline:
                     msg = f"{self.name}: index not ready after {timeout}s"
@@ -478,5 +534,5 @@ class ScyllaDB(VectorDB):
         """Create index (if deferred) and wait for it to be fully built before search benchmarks."""
         if self.case_config.create_index_after_upload:
             session = self._ensure_session()
-            _run(self._create_index(session))
+            self._run_async(self._create_index(session))
         self._wait_for_index_build()


### PR DESCRIPTION
## Replace scylla-driver with async python-rs-driver

Switch the ScyllaDB VectorDB client from the legacy `cassandra-driver`/`scylla-driver` to the new async, Rust-backed **python-rs-driver** (`scylla` package). This brings better performance, a modern async API, and positions the integration to benefit from ongoing driver improvements.

### Changes

**Driver migration** — Replace `cassandra.cluster.Cluster` with `SessionBuilder`/`Session` from the new `scylla` package. Batch inserts via `BatchStatement` are replaced with `asyncio.gather` for concurrent async execution. A `_run()` helper bridges the synchronous `VectorDB` interface with the async driver. The `pyproject.toml` dependency is updated to install from GitHub.

**Bug fix** — Fix `RuntimeError: no current event loop` in `insert_embeddings` on Python 3.10+ by moving the `asyncio.gather` call inside a proper async function executed within `_run()`.

**Performance optimizations** — Use a persistent event loop on a background thread instead of creating/destroying one per `_run()` call, eliminating major overhead on the `search_embedding` hot path. Set `Consistency.One` as the default execution profile and on prepared lookup statements. Prepare the index-probe query once instead of sending raw CQL on every poll iteration.

**Unit tests** — Add 31 tests across 8 test classes covering construction, `init()` lifecycle, insert dispatch, filter preparation, search, deferred index creation, schema variants, and credential handling. The `scylla` package is injected as fake modules so no driver installation is required to run the suite.

**Environment configuration** — Support `SCYLLADB_URI` environment variable (alongside existing `SCYLLADB_USERNAME`/`SCYLLADB_PASSWORD`) for host configuration via `environs`, with common setup extracted into a `_load_env()` helper. Document all ScyllaDB env vars in `.env.example`.

### Stats

4 files changed, **799 insertions**, 133 deletions
