### PR TITLE
Allow dynamic modification of number of dimensions

### DIFF
--- a/vectordb_bench/backend/clients/scylladb/config.py
+++ b/vectordb_bench/backend/clients/scylladb/config.py
@@ -39,6 +39,7 @@ class ScyllaDBIndexConfig(BaseModel, DBCaseConfig):
     oversampling: float | None = 1.0  # Search for oversampling * LIMIT results to improve recall
     index_scope: ScyllaDBIndexScope = ScyllaDBIndexScope.LOCAL  # Local vs global secondary index
     create_index_after_upload: bool = True  # Whether to create the index after data is uploaded
+    dim_override: int | None = None  # Override the number of vector dimensions (0 or None = use dataset default)
 
     def get_similarity_function_name(self) -> str:
         if self.metric_type == MetricType.COSINE:

--- a/vectordb_bench/backend/clients/scylladb/scylladb.py
+++ b/vectordb_bench/backend/clients/scylladb/scylladb.py
@@ -103,7 +103,13 @@ class ScyllaDB(VectorDB):
         **kwargs,
     ) -> None:
         self.name = "ScyllaDB"
-        self.dim = dim
+        self._original_dim = dim
+        # Apply dimension override if configured
+        override = getattr(db_case_config, "dim_override", None)
+        if override and override > 0:
+            self.dim = override
+        else:
+            self.dim = dim
         self.db_config = db_config
         self.case_config = db_case_config
         self.table_name = collection_name
@@ -394,6 +400,17 @@ class ScyllaDB(VectorDB):
         """Whether this database needs to normalize dataset to support COSINE."""
         return True
 
+    def _extend_vector(self, vec: list[float]) -> list[float]:
+        """Extend *vec* to ``self.dim`` dimensions by repeating coordinates."""
+        if self.dim <= len(vec):
+            return vec
+        original_len = len(vec)
+        extended = vec * (self.dim // original_len)
+        remainder = self.dim - len(extended)
+        if remainder:
+            extended.extend(vec[:remainder])
+        return extended
+
     def insert_embeddings(
         self,
         embeddings: Sequence[list[float]],
@@ -414,6 +431,9 @@ class ScyllaDB(VectorDB):
         Returns:
             Tuple of (inserted_count, error_or_None).
         """
+        if self.dim != self._original_dim:
+            embeddings = [self._extend_vector(e) for e in embeddings]
+
         session = self._ensure_session()
         assert self.prepared_insert is not None, "prepared_insert not initialized"
 
@@ -517,6 +537,9 @@ class ScyllaDB(VectorDB):
                 "call prepare_filter() before searching"
             )
             raise RuntimeError(msg)
+
+        if self.dim != self._original_dim:
+            query = self._extend_vector(query)
 
         result = self._run_async(
             session.execute(

--- a/vectordb_bench/backend/clients/scylladb/scylladb.py
+++ b/vectordb_bench/backend/clients/scylladb/scylladb.py
@@ -445,12 +445,25 @@ class ScyllaDB(VectorDB):
 
     # -- search & filtering --------------------------------------------------
 
+    def _ensure_index(self) -> None:
+        """Create the vector index if it does not already exist.
+
+        Called lazily from :meth:`prepare_filter` so that streaming
+        (read-while-write) tests can issue ANN queries even when
+        ``create_index_after_upload`` has deferred index creation past
+        the initial table setup.  The ``IF NOT EXISTS`` clause makes
+        this safe to call multiple times.
+        """
+        session = self._ensure_session()
+        self._run_async(self._create_index(session))
+
     def prepare_filter(self, filters: Filter) -> None:
         """Pre-prepare filter conditions to reduce redundancy during search.
 
         Filter values are bound via CQL prepared-statement parameters
         rather than interpolated into the query string.
         """
+        self._ensure_index()
         session = self._ensure_session()
 
         if filters.type == FilterOp.NonFilter:

--- a/vectordb_bench/frontend/config/dbCaseConfigs.py
+++ b/vectordb_bench/frontend/config/dbCaseConfigs.py
@@ -2014,6 +2014,18 @@ CaseConfigParamInput_create_index_after_upload_ScyllaDB = CaseConfigInput(
     inputConfig={"value": True},
 )
 
+CaseConfigParamInput_dim_override_ScyllaDB = CaseConfigInput(
+    label=CaseConfigParamType.scylladb_dim_override,
+    displayLabel="dim_override",
+    inputHelp="Override vector dimensions (0 = use dataset default). Vectors are extended by repeating coordinates.",
+    inputType=InputType.Number,
+    inputConfig={
+        "min": 0,
+        "max": 65536,
+        "value": 0,
+    },
+)
+
 LanceDBLoadConfig = [
     CaseConfigParamInput_IndexType_LanceDB,
     CaseConfigParamInput_num_partitions_LanceDB,
@@ -2056,6 +2068,7 @@ ScyllaDBLoadingConfig = [
     CaseConfigParamInput_ef_construction_ScyllaDB,
     CaseConfigParamInput_m_ScyllaDB,
     CaseConfigParamInput_create_index_after_upload_ScyllaDB,
+    CaseConfigParamInput_dim_override_ScyllaDB,
 ]
 
 ScyllaDBPerformanceConfig = [
@@ -2067,6 +2080,7 @@ ScyllaDBPerformanceConfig = [
     CaseConfigParamInput_rescoring_ScyllaDB,
     CaseConfigParamInput_index_scope_ScyllaDB,
     CaseConfigParamInput_create_index_after_upload_ScyllaDB,
+    CaseConfigParamInput_dim_override_ScyllaDB,
 ]
 
 # Map DB to config

--- a/vectordb_bench/models.py
+++ b/vectordb_bench/models.py
@@ -132,6 +132,7 @@ class CaseConfigParamType(Enum):
     scylladb_rescoring = "rescoring"
     scylladb_index_scope = "index_scope"
     scylladb_create_index_after_upload = "create_index_after_upload"
+    scylladb_dim_override = "dim_override"
 
 
 class CustomizedCase(BaseModel):


### PR DESCRIPTION
Add a numeric text box (dim_override) to the ScyllaDB test configuration
UI that allows overriding the number of vector dimensions. When set to a
value greater than 0, vectors are extended to the target dimension count
by cyclically repeating the original coordinates.

Changes:
- models.py: Add scylladb_dim_override enum value
- config.py: Add dim_override field to ScyllaDBIndexConfig
- dbCaseConfigs.py: Add dim_override input widget (0-65536, default 0)
- scylladb.py: Override self.dim in __init__, add _extend_vector() helper,
  extend vectors in insert_embeddings() and search_embedding()